### PR TITLE
Add plausible analytics

### DIFF
--- a/jekyll/_includes/head.html
+++ b/jekyll/_includes/head.html
@@ -34,6 +34,8 @@
 
   </script>
 
+  <script defer data-domain="nim-lang.org" src="https://plausible.io/js/plausible.js"></script>
+
   <meta name="twitter:title" content="{{ page.title | default: site.title  }}">
 
   {% if page.is_post %}


### PR DESCRIPTION
following up on a promise made in https://forum.nim-lang.org/t/9371#61603

this could be a first step to remove google analytics, the idea would be to have this running in parallel and see if it is worth or not removing google analytics later, see https://github.com/nim-lang/website/issues/226

- I have set up my plausible analytics subscription to track nim-lang.org
- my subscription is a paid subscription with currently space for more than 350K monthly pageviews
- my intention would be to keep paying for this as part of my sponsorship effort for nim
- statistics are set to be publicly available here: https://plausible.io/nim-lang.org (for the moment there is nothing, stats will start to appear once - if - this is merged)
- I can invite other people to "manage" this subscription
- in particular if someone has access to google analytics, we can later import all google analytics historical data in plausible: https://plausible.io/docs/google-analytics-import
- the specific change implemented here is adding the script for plausible just below the one for google analytics, I think this should be enough for having plausible analytics working

one thing that at some point we might want to add (if this is approved, not necessarily in this PR), is mention of plausible analytics somewhere in the site with the link to go to the dashboard (or directly embed the dashboard in some page).